### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-AccelerometerADXL335   KEYWORD1
+AccelerometerADXL335	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-getVoltageX   KEYWORD2
-getVoltageY   KEYWORD2
-getVoltageZ    KEYWORD2
-getVoltageXYZ    KEYWORD2
+getVoltageX	KEYWORD2
+getVoltageY	KEYWORD2
+getVoltageZ	KEYWORD2
+getVoltageXYZ	KEYWORD2
 
 #to do ....
 
@@ -23,5 +23,5 @@ getVoltageXYZ    KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-GRAVITY LITERAL1
-N_READINGS_DEFAULT LITERAL1
+GRAVITY	LITERAL1
+N_READINGS_DEFAULT	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords